### PR TITLE
Use 20 nodejs version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ branding:
   color: blue
   icon: delete
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: yc-actions/yc-cdn-cache@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.